### PR TITLE
Make buttercup tests work

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -54,11 +54,16 @@ in rec
     '';
   };
 
-  buttercup = pkgs.stdenv.mkDerivation {
-    name = name + "-buttercup";
-    buildInputs = [ emacsWithButtercup ];
-    shellHook =
-      ''
+  buttercup =
+    let
+      loadFiles = builtins.concatStringsSep " "
+        (map (filename: "--load " + filename) targetFiles);
+    in
+      pkgs.stdenv.mkDerivation {
+        name = name + "-buttercup";
+        buildInputs = [ emacsWithButtercup ];
+        shellHook =
+          ''
       echo "Running buttercup..."
       set -e
       out=$(mktemp)
@@ -66,9 +71,10 @@ in rec
       emacs --batch --no-site-file \
           --load package --eval '(setq package-archives nil)' \
           -f package-initialize \
+          ${loadFiles} \
           --load buttercup -f buttercup-run-discover
       exit
       '';
-  };
+      };
 
 }

--- a/tests/hello-tests.el
+++ b/tests/hello-tests.el
@@ -1,4 +1,10 @@
 ;; buttercup tests
+(require 'hello)
+
 (describe "example test group"
   (it "always succeed"
     (expect t :to-be t)))
+
+(describe "hello-identity from hello.el"
+  (it "returns the argument"
+    (expect (hello-identity 'hello) :to-be 'hello)))

--- a/tests/hello.el
+++ b/tests/hello.el
@@ -38,5 +38,9 @@
   (interactive)
   (message "Hello"))
 
+(defun hello-identity (x)
+  "Return X."
+  x)
+
 (provide 'hello)
 ;;; hello.el ends here


### PR DESCRIPTION
Load elisp files specified in `targetFiles` before running tests. This is required if you have to load the tested library in test files, which is definitely a requirement for package tests.