### PR TITLE
Allow omitting dependencies in package definitions

### DIFF
--- a/nix/lib/package.nix
+++ b/nix/lib/package.nix
@@ -24,14 +24,14 @@ with builtins; {
           value = x // {
             src = srcDir;
             recipe = pkgs.writeText "recipe" x.recipe;
-            dependencies = packageListFromNames x.dependencies;
-            testDependencies = packageListFromNames x.testDependencies;
+            dependencies = packageListFromNames (x.dependencies or [ ]);
+            testDependencies = packageListFromNames (x.testDependencies or [ ]);
             localDependencies =
               forEach x.localDependencies (depName: self."${depName}");
             # Only used for information to the user
-            dependencyNames = x.dependencies;
-            testDependencyNames = x.testDependencies;
-            localDependencyNames = x.localDependencies;
+            dependencyNames = x.dependencies or [ ];
+            testDependencyNames = x.testDependencies or [ ];
+            localDependencyNames = x.localDependencies or [ ];
           };
         }));
     in fix f;


### PR DESCRIPTION
To handle this case: https://github.com/akirak/org-multi-wiki/runs/836985481?check_suite_focus=true

Dependencies and test dependencies should be optional and default to empty. 