### PR TITLE
Add extra checks by melpazoid

### DIFF
--- a/.github/workflows/elisp-ci.yml
+++ b/.github/workflows/elisp-ci.yml
@@ -29,3 +29,5 @@ jobs:
     - run: melpa-check byte-compile -e ${{ matrix.emacs }} checkdoc-runner
     - run: melpa-check lint package-lint-runner || echo Ignoring
     - run: melpa-check byte-compile -e ${{ matrix.emacs }} package-lint-runner
+    - run: melpa-check lint melpazoid-misc-runner || echo Ignoring
+    - run: melpa-check byte-compile -e ${{ matrix.emacs }} melpazoid-misc-runner

--- a/.github/workflows/elisp-ci.yml
+++ b/.github/workflows/elisp-ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install
       run: nix-env -iA cli.gh-action -f .
     - run: melpa-check deps
-    - run: melpa-check config -f nix/checkers/tests
+    - run: melpa-check config -f nix/checkers/tests || echo Ignoring
     # Continue even if there is an error
     - run: melpa-check lint checkdoc-runner || echo Ignoring
     - run: melpa-check byte-compile -e ${{ matrix.emacs }} checkdoc-runner

--- a/nix/checkers/default.nix
+++ b/nix/checkers/default.nix
@@ -3,6 +3,7 @@ config: {
   package-lint = import ./package-lint.nix config;
   preparePackageLint = package:
     (import ./package-lint.nix config package).emacsWithPackagesDrv;
+  melpazoid-misc = import ./melpazoid-misc.nix config;
   byte-compile = import ./byte-compile.nix config;
   melpaBuild = import ./melpa-build.nix config;
   buttercup = import ./buttercup.nix config;

--- a/nix/checkers/melpazoid-misc-runner.el
+++ b/nix/checkers/melpazoid-misc-runner.el
@@ -1,0 +1,82 @@
+;;; melpazoid-misc-runner.el --- Run extra checks by melpazoid -*- lexical-binding: t -*-
+
+;; Copyright (C) 2020 Akira Komamura
+
+;; Author: Akira Komamura <akira.komamura@gmail.com>
+;; Version: 0.1
+;; Package-Requires: ((emacs "25.1") (melpazoid "0"))
+;; Keywords: lisp maint
+;; URL: https://github.com/akirak/melpa-check
+
+;; This file is not part of GNU Emacs.
+
+;;; License:
+
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This file provides a function for running misc checks from
+;; melpazoid in batch mode.
+
+;;; Code:
+
+(require 'melpazoid)
+(require 'thingatpt)
+(require 'subr-x)
+
+(defun melpazoid-misc-runner-batch ()
+  "Perform extra static checks using melpazoid."
+  (message "Running the following checks from melpazoid.el:")
+  (message "- melpazoid-check-sharp-quotes")
+  (message "- melpazoid-check-misc")
+  (message "----------------------------------------------------------")
+  (message "Running checks on %s..." (string-join command-line-args-left " "))
+  ;; Prevent printing the header
+  (setq melpazoid--misc-header-printed-p t)
+  (let (file has-errors)
+    (while (setq file (pop command-line-args-left))
+      (ignore-errors
+        (kill-buffer melpazoid-buffer))
+      (let ((file-buf (create-file-buffer file)))
+        (with-current-buffer file-buf
+          (setq buffer-file-name file)
+          (insert-file-contents file)
+          (melpazoid-check-sharp-quotes)
+          (melpazoid-check-misc))
+        (let ((err-buf (get-buffer melpazoid-buffer)))
+          (when (and err-buf
+                     (buffer-live-p err-buf)
+                     (> (buffer-size err-buf) 0))
+            (with-current-buffer err-buf
+              (goto-char (point-min))
+              (while (and (< (point) (point-max))
+                          (looking-at (rx (+ anything))))
+                (let* ((err (substring (thing-at-point 'line t) 2))
+                       (loc (and (string-match (rx "#L" (group (+ digit))
+                                                   ": ")
+                                               err)
+                                 (read (match-string 1 err))))
+                       (source (with-current-buffer file-buf
+                                 (forward-line (- loc
+                                                  (line-number-at-pos)))
+                                 (string-trim-right
+                                  (thing-at-point 'line t)))))
+                  (message "\n%s> %s" err source)
+                  (setq has-errors t))
+                (forward-line)))))))
+    (kill-emacs (when has-errors 1))))
+
+(provide 'melpazoid-misc-runner)
+;;; melpazoid-misc-runner.el ends here

--- a/nix/checkers/melpazoid-misc.nix
+++ b/nix/checkers/melpazoid-misc.nix
@@ -1,0 +1,37 @@
+config@{ pkgs, customEmacsPackages, ... }:
+package:
+with (import ../lib { inherit pkgs; });
+with (import ./test-base.nix config);
+let
+  emacsWithPackagesDrv = customEmacsPackages.emacsWithPackages (_: [ ]);
+
+  melpazoidEl = "${(import ../sources.nix).melpazoid}/melpazoid/melpazoid.el";
+
+  drv = pkgs.stdenv.mkDerivation {
+    name = package.pname + "-melpazoid-misc";
+    buildInputs = [ emacsWithPackagesDrv ];
+    shellHook = ''
+      echo
+      echo ==========================================================
+      echo melpazoid on ${package.pname} package
+      echo ==========================================================
+      cd ${package.src}
+      emacs --no-site-file --batch \
+         --eval "(setq noninteractive nil)" \
+         -l ${melpazoidEl} \
+         -l ${./melpazoid-misc-runner.el} \
+         -f melpazoid-misc-runner-batch \
+         ${concatShArgs package.files}
+      result=$?
+      echo ----------------------------------------------------------
+      if [[ $result -eq 0 ]]; then
+        echo "No melpazoid errors found."
+      else
+        echo "Errors found by melpazoid."
+      fi
+      # Prevent from actually entering the shell
+      exit $result
+    '';
+  };
+in drv // { inherit emacsWithPackagesDrv; }
+

--- a/nix/checkers/tests/packages.dhall
+++ b/nix/checkers/tests/packages.dhall
@@ -22,4 +22,15 @@ in  [ Package::{
           (checkdoc-runner :fetcher github :repo "akirak/melpa-check" :files ("nix/checkers/checkdoc-runner.el"))
           ''
       }
+    , Package::{
+      , pname = "melpazoid-misc-runner"
+      , version = "0.1"
+      , emacsVersion = "25.1"
+      , files = [ "nix/checkers/melpazoid-misc-runner.el" ]
+      , dependencies = [] : List Text
+      , recipe =
+          ''
+          (melpazoid-misc-runner :fetcher github :repo "akirak/melpa-check" :files ("nix/checkers/melpazoid-misc-runner.el"))
+          ''
+      }
     ]

--- a/nix/checkers/tests/packages.dhall
+++ b/nix/checkers/tests/packages.dhall
@@ -27,7 +27,8 @@ in  [ Package::{
       , version = "0.1"
       , emacsVersion = "25.1"
       , files = [ "nix/checkers/melpazoid-misc-runner.el" ]
-      , dependencies = [] : List Text
+      , dependencies = [ "melpazoid" ]
+      , localDependencies = [ "melpazoid" ]
       , recipe =
           ''
           (melpazoid-misc-runner :fetcher github :repo "akirak/melpa-check" :files ("nix/checkers/melpazoid-misc-runner.el"))

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -23,6 +23,18 @@
         "url": "https://github.com/justinwoo/easy-purescript-nix/archive/d4879bfd2b595d7fbd37da1a7bea5d0361975eb3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "melpazoid": {
+        "branch": "master",
+        "description": "A bundle of CI scripts for testing Emacs packages, primarily submissions to MELPA.",
+        "homepage": "",
+        "owner": "riscy",
+        "repo": "melpazoid",
+        "rev": "382db43a29340dcbd8f7414a9ade19944d12e12c",
+        "sha256": "1d48ky67i67chm19s6k35qs0msh1pnldqw46lx7h414rf20bhgb5",
+        "type": "tarball",
+        "url": "https://github.com/riscy/melpazoid/archive/382db43a29340dcbd8f7414a9ade19944d12e12c.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",

--- a/programs.nix
+++ b/programs.nix
@@ -162,6 +162,8 @@ in {
   preparePackageLint =
     mapPackage1 checkers.preparePackageLint "preparePackageLint";
 
+  melpazoid-misc = mapPackage1 checkers.melpazoid-misc "melpazoid-misc";
+
   # A task to silent build output in buttercup.
   # To be run by nix-build with --no-build-output as a preparation step.
   prepareButtercup = mapPackage1 checkers.prepareButtercup "prepareButtercup";

--- a/tests/bad-hello.el
+++ b/tests/bad-hello.el
@@ -29,7 +29,11 @@
 ;;;###autoload
 (defun bad-hello-message ()
   (interactive)
+  (when (not t)
+    t)
   (message "Hello"))
+
+(bind-keys ("<f12> <f11> <f10>" . #'emacs-version))
 
 (provide 'bad-hello)
 ;;; bad-hello.el ends here

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -17,6 +17,8 @@ nix-shell -A checkdoc.default
 nix-build -A byte-compile.default
 nix-shell -A package-lint.hello
 nix-shell -A package-lint.hello2
+nix-shell -A melpazoid-misc.hello
+nix-shell -A melpazoid-misc.hello2
 # nix-build -A prepareButtercup.hello --no-build-output
 nix-shell -A buttercup.hello
 # nix-build -A prepareAllTests.hello2 --no-build-output
@@ -29,6 +31,7 @@ nix-shell ert -A ert.hello3
 ! nix-shell bad.nix -A checkdoc.default
 ! nix-build bad.nix -A byte-compile.default
 ! nix-shell bad.nix -A package-lint.bad-hello
+! nix-shell bad.nix -A melpazoid-misc.bad-hello
 # nix-build ert -A prepareErt.hello4
 ! nix-shell ert -A ert.hello4
 

--- a/tests/hello-util.el
+++ b/tests/hello-util.el
@@ -21,7 +21,7 @@
 ;; GNU General Public License for more details.
 ;;
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/tests/hello.el
+++ b/tests/hello.el
@@ -22,7 +22,7 @@
 ;; GNU General Public License for more details.
 ;;
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 

--- a/tests/hello2.el
+++ b/tests/hello2.el
@@ -22,7 +22,7 @@
 ;; GNU General Public License for more details.
 ;;
 ;; You should have received a copy of the GNU General Public License
-;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 ;;; Commentary:
 


### PR DESCRIPTION
This adds the following checks by [melpazoid](https://github.com/riscy/melpazoid):

- `melpazoid-check-sharp-quotes`
- `melpazoid-check-misc`

Implementation status:

- [x] Add Nix API for running the check
- [ ] Extend the CLI to support the functionality

I plan on adding the check to `lint` command of the CLI. It will be the default, but I will add a switch to disable the check (like `--no-melpazoid`).

The output will be like this:

```
==========================================================
melpazoid on bad-hello package
==========================================================
Running the following checks from melpazoid.el:
- melpazoid-check-sharp-quotes
- melpazoid-check-misc
----------------------------------------------------------
Running checks on tests/bad-hello.el...

bad-hello.el#L36: Top-level bind-keys can overwrite user keybindings.  Try: `(defvar my-map (let ((km (make-sparse-keymap))) (bind-keys ...) km))`
> (bind-keys ("<f12> <f11> <f10>" . #'emacs-version))

bad-hello.el#L32: Consider `unless ...` instead of `when (not ...)`
>   (when (not t)

bad-hello.el#L19: Prefer `https` over `http` (if possible)
> ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
----------------------------------------------------------
Errors found by melpazoid.
```