### PR TITLE
Add support for loadability testing

### DIFF
--- a/nix/checkers/default.nix
+++ b/nix/checkers/default.nix
@@ -8,6 +8,9 @@ config: {
   buttercup = import ./buttercup.nix config;
   prepareButtercup = package:
     (import ./buttercup.nix config package).emacsWithPackagesDrv;
+  load = import ./load.nix config;
+  prepareLoad = package:
+    (import ./load.nix config package).emacsWithPackagesDrv;
   ert = import ./ert.nix config;
   prepareErt = package: (import ./ert.nix config package).emacsWithPackagesDrv;
   ert-runner = import ./ert-runner.nix config;

--- a/nix/checkers/load.nix
+++ b/nix/checkers/load.nix
@@ -1,0 +1,30 @@
+config@{ pkgs, customEmacsPackages, ... }:
+package:
+with (import ../lib { inherit pkgs; });
+with (import ./test-base.nix config);
+let
+  emacsWithPackagesDrv =
+    customEmacsPackages.emacsWithPackages (epkgs: [ (melpaBuild package) ]);
+  drv = pkgs.stdenv.mkDerivation {
+    name = package.pname + "-loadability";
+    buildInputs = [ emacsWithPackagesDrv ];
+    shellHook = ''
+      echo
+      echo ==========================================================
+      echo Load ${package.pname} package
+      echo ==========================================================
+      emacs --version
+      echo
+      emacs --no-site-file --batch -l ${package.pname}
+      result=$?
+      echo ----------------------------------------------------------
+      if [[ $result -eq 0 ]]; then
+        echo "Successfully loaded the package."
+      else
+        echo "Failed to load the package."
+      fi
+      # Prevent from actually entering the shell
+      exit $result
+    '';
+  };
+in drv // { inherit emacsWithPackagesDrv; }

--- a/nix/checkers/test-base.nix
+++ b/nix/checkers/test-base.nix
@@ -147,5 +147,5 @@ let
 in {
   inherit makeTestDerivation makeTestDerivation2 makeTestHeader
     packageInstallCommand packageInstallCommandForTesting
-    withMutableSourceDirectory emacsDerivationForTesting;
+    withMutableSourceDirectory emacsDerivationForTesting melpaBuild;
 }

--- a/programs.nix
+++ b/programs.nix
@@ -162,6 +162,10 @@ in {
   preparePackageLint =
     mapPackage1 checkers.preparePackageLint "preparePackageLint";
 
+  prepareLoad = mapPackage1 checkers.prepareLoad "prepareLoad";
+
+  load = mapPackage1 checkers.load "load";
+
   # A task to silent build output in buttercup.
   # To be run by nix-build with --no-build-output as a preparation step.
   prepareButtercup = mapPackage1 checkers.prepareButtercup "prepareButtercup";

--- a/tests/ci.sh
+++ b/tests/ci.sh
@@ -17,6 +17,10 @@ nix-shell -A checkdoc.default
 nix-build -A byte-compile.default
 nix-shell -A package-lint.hello
 nix-shell -A package-lint.hello2
+nix-build -A prepareLoad.hello --no-build-output
+nix-shell -A load.hello
+nix-build -A prepareLoad.hello2 --no-build-output
+nix-shell -A load.hello2
 # nix-build -A prepareButtercup.hello --no-build-output
 nix-shell -A buttercup.hello
 # nix-build -A prepareAllTests.hello2 --no-build-output
@@ -29,6 +33,8 @@ nix-shell ert -A ert.hello3
 ! nix-shell bad.nix -A checkdoc.default
 ! nix-build bad.nix -A byte-compile.default
 ! nix-shell bad.nix -A package-lint.bad-hello
+! nix-build bad.nix -A prepareLoad.bad-hello --no-build-output
+! nix-shell bad.nix -A load.bad-hello
 # nix-build ert -A prepareErt.hello4
 ! nix-shell ert -A ert.hello4
 


### PR DESCRIPTION
This is another feature from [melpazoid](https://github.com/riscy/melpazoid).

Rather than loading a source file directly, this first builds the package using `melpaBuild` function and then loads its main file. Thus the package files are structured based on the recipe, which makes the testing more strict.

Status:

- [x] Add the core API
- [ ] Add a CLI command
- [ ] Add to the workflow template