### PR TITLE
Add ELINTER_ALLOW_WARNINGS environment variable

### DIFF
--- a/action.bash
+++ b/action.bash
@@ -27,11 +27,4 @@ workflow_end_group
 
 echo
 
-flags=()
-
-if [[ "${ELINTER_ACTION_EXPERIMENTAL}" != "0" ]]; then
-  flags+=("--experimental")
-fi
-
-# shellcheck disable=SC2068
-elinter -e all ${flags[@]}
+elinter -e all

--- a/action.bash
+++ b/action.bash
@@ -20,7 +20,9 @@ cachix use emacs-ci
 workflow_end_group
 
 workflow_start_group "Install elinter"
-nix-env -if https://github.com/akirak/elinter/archive/v4.tar.gz -A main
+if ! command elinter >/dev/null; then
+  nix-env -if https://github.com/akirak/elinter/archive/v4.tar.gz -A main
+fi
 workflow_end_group
 
 echo

--- a/action.yml
+++ b/action.yml
@@ -1,16 +1,7 @@
 name: 'elinter'
 description: 'Lint Emacs Lisp packages'
-inputs:
-  experimental:
-    description: 'Turn on experimental checks (true/warn/false)'
-    required: false
-    default: true
 runs:
   using: 'composite'
   steps:
     - run: $GITHUB_ACTION_PATH/action.bash
       shell: bash
-      env:
-        ELINTER_ACTION_EXPERIMENTAL: ${{ inputs.experimental }}
-        ELINTER_MELPAZOID_ALLOW_FAILURE: ${{ inputs.experimental == 'warn' }}
-      # TODO: Add badge

--- a/lisp/elinter-run-linters.el
+++ b/lisp/elinter-run-linters.el
@@ -159,15 +159,15 @@
                             'warning
                           t))))))
 
-(defvar elinter-continueing nil)
+(defvar elinter-continuing nil)
 
 (defun elinter-run-linter (linter)
   "Run a LINTER by name."
   (let ((func (intern (concat "elinter-" linter))))
     ;; Insert an empty line
-    (if elinter-continueing
+    (if elinter-continuing
         (message "")
-      (setq elinter-continueing t))
+      (setq elinter-continuing t))
     (condition-case err
         (progn
           (message "Running %s..." linter)


### PR DESCRIPTION
1. Add `ELINTER_ALLOW_WARNINGS` environment variable, which lets the user configure which linters (or all linters) should allow warnings and exit successfully.
2. To select which linters to use in GitHub Actions, set `ELINTER_LINTERS` and `ELINTER_ALLOW_WARNINGS` environment variables.
3. Some tidying up of code.