### PR TITLE
Prevent 'arguments list too long' error

### DIFF
--- a/bin/elinter
+++ b/bin/elinter
@@ -309,15 +309,16 @@ cleanup_cache() {
 }
 
 copy_package_sources() {
+  local recipe_file
   echo "Linking package source files..."
   mkdir -p "${package_source_root}"
   initialdir="$(pwd)"
   for f in ${recipes[*]}; do
     package=$(basename "$f")
     if [[ "$f" = /* ]]; then
-      recipe="$(cat "$f")"
+      recipe_file="$(readlink -f "$f")"
     else
-      recipe="$(cat "$initialdir/$f")"
+      recipe_file="$(readlink -f "$initialdir/$f")"
     fi
     packages+=("$package")
     src="$initialdir"
@@ -327,7 +328,7 @@ copy_package_sources() {
       rm -rf "$package"
       src=$(nix-instantiate --eval --strict \
               "share/nix/fetchSource.nix" \
-              --argstr recipe "$recipe" | tr -d \")
+              --argstr recipeFile "${recipe_file}" | tr -d \")
     elif [[ -d "$package" ]]; then
       # TODO: Check for updates in the working tree
       echo
@@ -337,7 +338,7 @@ copy_package_sources() {
     fi
     instruction=$(nix-build "share/nix/copySource.nix" \
             --no-out-link --quiet --no-build-output \
-            --argstr recipe "$recipe" --argstr src "$src")
+            --argstr recipeFile "${recipe_file}" --argstr src "$src")
     mkdir "$package"
     cd "${package_source_root}/$package"
     # shellcheck disable=SC1090
@@ -345,7 +346,7 @@ copy_package_sources() {
     echo
     echo "Package: $package"
     # shellcheck disable=SC2001
-    echo "${recipe}" | sed 's/^/> /'
+    sed 's/^/> /' "${recipe_file}"
     echo -n "Files: "
     ls
   done

--- a/nix/copySource.nix
+++ b/nix/copySource.nix
@@ -1,6 +1,6 @@
 { pkgs ? import <nixpkgs> {}
 , src
-, recipe
+, recipeFile
 }:
 with builtins;
 with pkgs;
@@ -10,7 +10,7 @@ let
   srcRoot = gitignoreSource (/. + "/${src}");
   package =
     let
-      recipeAttrs = parseRecipe recipe;
+      recipeAttrs = parseRecipe (readFile recipeFile);
       isElisp = file: match ".+\.el" file != null;
       mainFileRegex = "(.*/)?" + recipeAttrs.pname + "\.el";
       isMainFile = file: match mainFileRegex file != null;

--- a/nix/fetchSource.nix
+++ b/nix/fetchSource.nix
@@ -1,10 +1,10 @@
 { pkgs ? import <nixpkgs> {}
-, recipe
+, recipeFile
 }:
 with builtins;
 with pkgs;
 with (import (import ./sources.nix).nix-elisp-helpers { inherit pkgs; });
-with (parseRecipe recipe);
+with (parseRecipe (readFile recipeFile));
 let
   path = split "/" repo;
   owner = elemAt path 0;

--- a/test/recipe1
+++ b/test/recipe1
@@ -1,0 +1,1 @@
+(smex :repo "nonsequitur/smex" :fetcher github)

--- a/test/recipe2
+++ b/test/recipe2
@@ -1,0 +1,3 @@
+(flymake-perlcritic :repo "illusori/emacs-flymake-perlcritic"
+                    :fetcher github
+                    :files ("*.el" ("bin" "bin/flymake_perlcritic")))

--- a/test/recipe3
+++ b/test/recipe3
@@ -1,0 +1,1 @@
+(discover-my-major :fetcher git :url "https://framagit.org/steckerhalter/discover-my-major.git")

--- a/test/test-recipe-source.nix
+++ b/test/test-recipe-source.nix
@@ -1,21 +1,11 @@
 let
   pkgs = import <nixpkgs> {};
-  fetchRecipeSource = recipe: import ../nix/fetchSource.nix {
-    inherit recipe;
+
+  fetchRecipeSource = recipeFile: import ../nix/fetchSource.nix {
+    inherit recipeFile;
   };
-  recipe1 = ''
-    (smex :repo "nonsequitur/smex" :fetcher github)
-  '';
-  recipe2 = ''
-    (flymake-perlcritic :repo "illusori/emacs-flymake-perlcritic"
-                        :fetcher github
-                        :files ("*.el" ("bin" "bin/flymake_perlcritic")))
-  '';
-  recipe3 = ''
-    (discover-my-major :fetcher git :url "https://framagit.org/steckerhalter/discover-my-major.git")
-  '';
 in
-  assert (pkgs.lib.isStorePath (fetchRecipeSource recipe1));
-  assert (pkgs.lib.isStorePath (fetchRecipeSource recipe2));
-  assert (pkgs.lib.isStorePath (fetchRecipeSource recipe3));
+  assert (pkgs.lib.isStorePath (fetchRecipeSource ./recipe1));
+  assert (pkgs.lib.isStorePath (fetchRecipeSource ./recipe2));
+  assert (pkgs.lib.isStorePath (fetchRecipeSource ./recipe3));
   null


### PR DESCRIPTION
Passing each recipe as a file and not as a string, since it can contain whitespaces, double quotes, etc.