### PR TITLE
WIP: Improve error messaging for invalid recipe files

### DIFF
--- a/bin/elinter
+++ b/bin/elinter
@@ -62,7 +62,7 @@ else
 fi
 
 usage() {
-  # Follow the style in docopt https://docopt.org/
+  # Follow the style in docopt http://docopt.org/
   cat <<HELP
 Usage: elinter [options] <recipe>...
 

--- a/bin/elinter
+++ b/bin/elinter
@@ -273,6 +273,7 @@ copy_package_sources() {
   initialdir="$(pwd)"
   # Operate on each package recipe
   for f in ${recipes[*]}; do
+    echo "Linking package source files for recipe ${f} ..."
     # Use the base name of the recipe file as the package name
     package=$(basename "$f")
     # Convert to an absolute path

--- a/nix/copySource.nix
+++ b/nix/copySource.nix
@@ -29,12 +29,11 @@ let
         filter (file: match "(.*/)?flycheck_.+\.el" file == null)
           (expandPackageFiles srcRoot recipeAttrs.files);
       sourceFiles = filter isElisp packageFiles;
+      mainFiles = (filter isMainFile sourceFiles);
       mainFile =
         if length sourceFiles == 1
         then head sourceFiles
         else
-          let mainFiles = (filter isMainFile sourceFiles);
-          in
           if mainFiles == [ ]
           then abort "Main elisp file not found for recipe ${recipeFile}."
           else head mainFiles;

--- a/nix/copySource.nix
+++ b/nix/copySource.nix
@@ -32,7 +32,12 @@ let
       mainFile =
         if length sourceFiles == 1
         then head sourceFiles
-        else head (filter isMainFile sourceFiles);
+        else
+          let mainFiles = (filter isMainFile sourceFiles);
+          in
+          if mainFiles == [ ]
+          then abort "Main elisp file not found for recipe ${recipeFile}."
+          else head mainFiles;
     };
 in
 with package;


### PR DESCRIPTION
Thank you for an excellent tool!

I recently had a problem that took some time to debug.

When running elinter locally, I had an emacs backup file in my `.recipes` directory:

```
[nix-shell:~/elisp/foo]$ ls .recipes/
foo  foo~
```

This was picked up when running elinter:

```
Looking for recipes in .recipes...
Found .recipes/foo .recipes/foo~

Linking package source files...

Reusing the previous settings for foo:
foo.el
error: list index 0 is out of bounds, at /nix/store/d5hxq1xqrl93f7si3hrksikvzkdh1q2b-elinter-share/share/elinter/nix/copySource.nix:35:16
(use '--show-trace' to show detailed location information)
```

The `foo~` recipe pointed to a non-existent source file.

The `copySource.nix` expression takes the head of the source files, aborting with the above out of bounds error if there are no source files:

```
head (filter isMainFile sourceFiles)
```

This took me a while to debug - I didn't realize that the error was thrown when processing the `foo~` recipe

What do you think about adding a per-recipe logging statement?

This PR prints:
```
Linking package source files for recipe .recipes/foo~ ...
error: evaluation aborted with the following error message: 'Main elisp file not found for recipe /home/zainab/elisp/foo/.recipes/foo~.'
(use '--show-trace' to show detailed location information)
```

I'm marking this as a WIP while I figure out what's wrong with my `nixpkgs-fmt` hook. I assume that the hook shouldn't have reformatted the entire `copySources.nix` file.