### PR TITLE
Allow to set :files spec on recipe generation

### DIFF
--- a/elinter.el
+++ b/elinter.el
@@ -154,11 +154,23 @@ ROOT is the project, and RECIPE is a package recipe."
         (unless (file-exists-p recipe-file)
           (with-current-buffer (create-file-buffer recipe-file)
             (let* ((fetcher-spec (elinter--fetcher-spec))
-                   ;; TODO: Generate files spec
+                   ;; TODO: Provide better suggestions for :files spec
+                   ;; by reading the dependencies.
+                   (files-spec (read-from-minibuffer
+                                (format "Enter :files spec for %s (optional): " package-name)
+                                ;; If there are multiple packages in the repository,
+                                ;; you will probably need :files spec.
+                                (when (or recipes
+                                          (> (length new-main-files) 1))
+                                  (prin1-to-string (list (file-relative-name main-file root))))
+                                nil
+                                #'read))
                    (recipe (read--expression
                             (format "Confirm recipe for \"%s\": " package-name)
                             (prin1-to-string `(,(intern package-name)
-                                               ,@fetcher-spec)))))
+                                               ,@fetcher-spec
+                                               ,@(when files-spec
+                                                   (list :files files-spec)))))))
               (insert (prin1-to-string recipe))
               (setq buffer-file-name recipe-file)
               (setq uncovered-files (cl-set-difference uncovered-files

--- a/elinter.el
+++ b/elinter.el
@@ -172,13 +172,16 @@ ROOT is the project, and RECIPE is a package recipe."
                                                ,@(when files-spec
                                                    (list :files files-spec)))))))
               (insert (prin1-to-string recipe))
+              (when (search-backward ":files")
+                (insert "\n"))
               (setq buffer-file-name recipe-file)
               (setq uncovered-files (cl-set-difference uncovered-files
                                                        (elinter--expand-files-in-recipe
                                                         root
                                                         recipe)
                                                        :test #'string-equal))
-              (emacs-lisp-mode)
+              (delay-mode-hooks (emacs-lisp-mode))
+              (indent-region (point-min) (point-max))
               (save-buffer))))
         (message "Copying %s to %s" package-name dest-dir)
         (copy-file recipe-file (expand-file-name package-name dest-dir))))))


### PR DESCRIPTION
Allow the user to interactively specify `:files` spec for each recipe.